### PR TITLE
Bump cache table to v1, improve missing feed body handling

### DIFF
--- a/appglobals/appglobals.go
+++ b/appglobals/appglobals.go
@@ -14,7 +14,7 @@ import (
 type AppGlobals struct {
 	Config      config.Config
 	DB          *pgxpool.Pool
-	FeedStorage *feedstorage.Storage
+	FeedStorage feedstorage.Interface
 }
 
 func New(ctx context.Context, cfg config.Config) (ac *AppGlobals, err error) {

--- a/db/db.go
+++ b/db/db.go
@@ -39,7 +39,7 @@ func (db *DB) exec(ctx context.Context, query string, args ...interface{}) error
 
 func (db *DB) Migrate(ctx context.Context) error {
 	const q = `
-CREATE TABLE IF NOT EXISTS icalproxy_feeds_v1 (
+CREATE TABLE IF NOT EXISTS icalproxy_feeds_v2 (
     id BIGINT GENERATED ALWAYS AS IDENTITY PRIMARY KEY,
     url TEXT NOT NULL UNIQUE NOT NULL,
     -- Host TTL is specified using suffixes/ends with (icloud.com vs p123.icloud.com),
@@ -57,17 +57,17 @@ CREATE TABLE IF NOT EXISTS icalproxy_feeds_v1 (
     webhook_pending BOOL NOT NULL DEFAULT FALSE
 );
 -- See above for details on this index.
-CREATE INDEX IF NOT EXISTS icalproxy_feeds_v1_url_host_rev_idx ON icalproxy_feeds_v1(url_host_rev COLLATE "C");
+CREATE INDEX IF NOT EXISTS icalproxy_feeds_v2_url_host_rev_idx ON icalproxy_feeds_v2(url_host_rev COLLATE "C");
 -- Index checked_at since we need to know recent rows.
-CREATE INDEX IF NOT EXISTS icalproxy_feeds_v1_checked_at_idx ON icalproxy_feeds_v1(checked_at);
+CREATE INDEX IF NOT EXISTS icalproxy_feeds_v2_checked_at_idx ON icalproxy_feeds_v2(checked_at);
 -- Use partial index, we only need to check where something is pending, never where it's not.
-CREATE INDEX IF NOT EXISTS icalproxy_feeds_v1_webhook_pending_idx ON icalproxy_feeds_v1((1)) WHERE webhook_pending;
+CREATE INDEX IF NOT EXISTS icalproxy_feeds_v2_webhook_pending_idx ON icalproxy_feeds_v2((1)) WHERE webhook_pending;
 `
 	return db.exec(ctx, q)
 }
 
 func (db *DB) Reset(ctx context.Context) error {
-	const q = `DROP TABLE IF EXISTS icalproxy_feeds_v1;`
+	const q = `DROP TABLE IF EXISTS icalproxy_feeds_v2;`
 	return db.exec(ctx, q)
 }
 
@@ -79,7 +79,7 @@ type FeedRow struct {
 
 func (db *DB) FetchFeedRow(ctx context.Context, uri *url.URL) (*FeedRow, error) {
 	r := FeedRow{}
-	const q = `SELECT contents_md5, contents_last_modified, fetch_headers FROM icalproxy_feeds_v1 WHERE url = $1`
+	const q = `SELECT contents_md5, contents_last_modified, fetch_headers FROM icalproxy_feeds_v2 WHERE url = $1`
 	err := db.conn.QueryRow(ctx, q, uri.String()).Scan(&r.ContentsMD5, &r.ContentsLastModified, &r.FetchHeaders)
 	if err != nil {
 		if errors.Is(err, pgx.ErrNoRows) {
@@ -98,7 +98,7 @@ func (db *DB) FetchContentsAsFeed(ctx context.Context, feedStorage feedstorage.I
 	var feedId int64
 	const q = `SELECT
 	id, fetch_headers, fetch_status, checked_at, contents_md5, (CASE WHEN fetch_status >= 400 THEN fetch_error_body ELSE NULL END)
-FROM icalproxy_feeds_v1
+FROM icalproxy_feeds_v2
 WHERE url = $1`
 	err := db.conn.QueryRow(ctx, q, uri.String()).Scan(
 		&feedId, &fetchHeaders, &r.HttpStatus, &r.FetchedAt, &r.MD5, &r.Body,
@@ -144,7 +144,7 @@ func (db *DB) CommitFeed(ctx context.Context, feedStorage feedstorage.Interface,
 	}
 
 	if feed.HttpStatus >= 400 {
-		const errQuery = `INSERT INTO icalproxy_feeds_v1 
+		const errQuery = `INSERT INTO icalproxy_feeds_v2 
 (url, url_host_rev, checked_at, fetch_status, fetch_headers, fetch_error_body, contents_md5, contents_last_modified, contents_size)
 VALUES ($1, $2, $3, $4, $5, $6, '', $7, 0)
 ON CONFLICT (url) DO UPDATE SET
@@ -167,7 +167,7 @@ ON CONFLICT (url) DO UPDATE SET
 		}
 		return nil
 	}
-	const feedQuery = `INSERT INTO icalproxy_feeds_v1 
+	const feedQuery = `INSERT INTO icalproxy_feeds_v2 
 (url, url_host_rev, checked_at, fetch_status, fetch_headers, contents_md5, contents_last_modified, contents_size, fetch_error_body, webhook_pending)
 VALUES ($1, $2, $3, $4, $5, $6, $7, $8, '', $9)
 ON CONFLICT (url) DO UPDATE SET
@@ -206,7 +206,7 @@ RETURNING id`
 
 func (db *DB) CommitUnchanged(ctx context.Context, feed *feed.Feed) error {
 	fetchedTrunc := feed.FetchedAt.Truncate(time.Second)
-	const query = `UPDATE icalproxy_feeds_v1 SET checked_at = $1 WHERE url = $2`
+	const query = `UPDATE icalproxy_feeds_v2 SET checked_at = $1 WHERE url = $2`
 	if err := db.exec(ctx, query, fetchedTrunc, feed.Url); err != nil {
 		return internal.ErrWrap(err, "unable to update feed")
 	}
@@ -218,7 +218,7 @@ func (db *DB) CommitUnchanged(ctx context.Context, feed *feed.Feed) error {
 // it will only happen if something manually changes feed storage.
 func (db *DB) ExpireFeed(ctx context.Context, u *url.URL) error {
 	t := time.Time{}
-	const query = `UPDATE icalproxy_feeds_v1 SET checked_at = $1, contents_last_modified = $1 WHERE url = $2`
+	const query = `UPDATE icalproxy_feeds_v2 SET checked_at = $1, contents_last_modified = $1 WHERE url = $2`
 	if err := db.exec(ctx, query, t, u); err != nil {
 		return internal.ErrWrap(err, "unable to expire feed")
 	}

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -101,7 +101,7 @@ var _ = Describe("db", func() {
 			Expect(err).To(MatchError(ContainSubstring("no rows in result set")))
 		})
 		It("returns an error if the content is not stored", func() {
-			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v1(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
+			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v2(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
 VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '{}')`)
 			Expect(err).ToNot(HaveOccurred())
 			_, err = d.FetchContentsAsFeed(ctx, fs, fp.Must(url.Parse("https://localhost/feed")))
@@ -123,7 +123,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}, nil)).To(Succeed())
 			Expect(fs.Files).To(HaveLen(1))
 			rowv1 := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(fs.Files[rowv1.Id]).To(BeEquivalentTo("version1"))
@@ -151,7 +151,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 				FetchedAt:   t2,
 			}, nil)).To(Succeed())
 			rowv2 := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(fs.Files[rowv2.Id]).To(BeEquivalentTo("version2X"))
@@ -179,7 +179,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}, nil)).To(Succeed())
 			Expect(fs.Files).To(BeEmpty())
 			rowv1 := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rowv1).To(And(
@@ -206,7 +206,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}, nil)).To(Succeed())
 			Expect(fs.Files).To(BeEmpty())
 			rowv2 := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rowv2).To(And(
@@ -243,7 +243,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}, nil)).To(Succeed())
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -278,7 +278,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 				FetchedAt:   t2,
 			}, nil)).To(Succeed())
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -305,7 +305,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}
 			Expect(d.CommitFeed(ctx, fs, fd, &db.CommitFeedOptions{WebhookPending: true})).To(Succeed())
 			rowinsert := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rowinsert).To(And(
@@ -314,7 +314,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 
 			Expect(d.CommitFeed(ctx, fs, fd, &db.CommitFeedOptions{WebhookPending: true})).To(Succeed())
 			rowupdate := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rowupdate).To(And(
@@ -333,7 +333,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			}
 			Expect(d.CommitFeed(ctx, fs, fd, &db.CommitFeedOptions{WebhookPendingOnInsert: true})).To(Succeed())
 			rowinsert := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rowinsert).To(And(
@@ -357,7 +357,7 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			fd.FetchedAt = t
 			Expect(d.CommitUnchanged(ctx, fd)).To(Succeed())
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -368,12 +368,12 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 	})
 	Describe("ExpireFeed", func() {
 		It("resets the fetch-at time so TTL will be expired", func() {
-			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v1(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
+			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v2(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
 VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '{}')`)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(db.New(ag.DB).ExpireFeed(ctx, fp.Must(url.Parse("https://localhost/feed")))).To(Succeed())
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(

--- a/db/db_test.go
+++ b/db/db_test.go
@@ -10,6 +10,7 @@ import (
 	"github.com/webhookdb/icalproxy/config"
 	"github.com/webhookdb/icalproxy/db"
 	"github.com/webhookdb/icalproxy/feed"
+	"github.com/webhookdb/icalproxy/feedstorage"
 	"github.com/webhookdb/icalproxy/feedstorage/fakefeedstorage"
 	"github.com/webhookdb/icalproxy/fp"
 	. "github.com/webhookdb/icalproxy/icalproxytest"
@@ -99,14 +100,12 @@ var _ = Describe("db", func() {
 			_, err := d.FetchContentsAsFeed(ctx, fs, fp.Must(url.Parse("https://localhost/feed")))
 			Expect(err).To(MatchError(ContainSubstring("no rows in result set")))
 		})
-		It("returns an empty body if only the content row does not exist", func() {
+		It("returns an error if the content is not stored", func() {
 			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v1(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
 VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '{}')`)
 			Expect(err).ToNot(HaveOccurred())
-			r, err := d.FetchContentsAsFeed(ctx, fs, fp.Must(url.Parse("https://localhost/feed")))
-			Expect(err).ToNot(HaveOccurred())
-			Expect(r.Body).To(BeEmpty())
-			Expect(r.MD5).To(BeEquivalentTo("abc123"))
+			_, err = d.FetchContentsAsFeed(ctx, fs, fp.Must(url.Parse("https://localhost/feed")))
+			Expect(err).To(MatchError(feedstorage.ErrNotFound))
 		})
 	})
 	Describe("CommitFeed", func() {
@@ -364,6 +363,22 @@ VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '
 			Expect(row).To(And(
 				HaveField("CheckedAt", BeTemporally("==", t)),
 				HaveField("ContentsMD5", BeEquivalentTo("version1hash")),
+			))
+		})
+	})
+	Describe("ExpireFeed", func() {
+		It("resets the fetch-at time so TTL will be expired", func() {
+			_, err := ag.DB.Exec(ctx, `INSERT INTO icalproxy_feeds_v1(url, url_host_rev, checked_at, contents_md5, contents_last_modified, contents_size, fetch_status, fetch_headers)
+VALUES ('https://localhost/feed', 'TSOHLACOL', now(), 'abc123', now(), 5, 200, '{}')`)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(db.New(ag.DB).ExpireFeed(ctx, fp.Must(url.Parse("https://localhost/feed")))).To(Succeed())
+			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://localhost/feed'`)),
+				pgx.RowToStructByName[FeedRow],
+			))
+			Expect(row).To(And(
+				HaveField("CheckedAt", BeTemporally("==", time.Time{})),
+				HaveField("ContentsLastModified", BeTemporally("==", time.Time{})),
 			))
 		})
 	})

--- a/feedstorage/fakefeedstorage/fakefeedstorage.go
+++ b/feedstorage/fakefeedstorage/fakefeedstorage.go
@@ -23,7 +23,7 @@ func (f *FakeFeedStorage) Fetch(_ context.Context, feedId int64) ([]byte, error)
 	defer f.mux.Unlock()
 	b, ok := f.Files[feedId]
 	if !ok {
-		return nil, nil
+		return nil, feedstorage.ErrNotFound
 	}
 	return b, nil
 }

--- a/icalproxytest/icalproxytest.go
+++ b/icalproxytest/icalproxytest.go
@@ -27,7 +27,7 @@ type FeedRow struct {
 // which are usually only generated during testing.
 func TruncateLocal(ctx context.Context, db *pgxpool.Pool) error {
 	_, err := db.Exec(ctx, `
-DELETE FROM icalproxy_feeds_v1
+DELETE FROM icalproxy_feeds_v2
 WHERE starts_with(url_host_rev, reverse('127001')) OR starts_with(url_host_rev, reverse('LOCALHOST'))`)
 	if err != nil {
 		return err

--- a/notifier/notifier.go
+++ b/notifier/notifier.go
@@ -51,7 +51,7 @@ func (r *Notifier) processChunk(ctx context.Context) (int, error) {
 		start := time.Now()
 		logctx.Logger(ctx).DebugContext(ctx, "notifier_querying_chunk")
 		q := fmt.Sprintf(`SELECT id, url
-FROM icalproxy_feeds_v1
+FROM icalproxy_feeds_v2
 WHERE webhook_pending
 LIMIT %d
 FOR UPDATE SKIP LOCKED
@@ -92,7 +92,7 @@ FOR UPDATE SKIP LOCKED
 		} else if resp.StatusCode >= 400 {
 			return fmt.Errorf("error sending webhook: %d", resp.StatusCode)
 		}
-		if _, err := tx.Exec(ctx, `UPDATE icalproxy_feeds_v1 SET webhook_pending=false WHERE id = ANY($1)`, ids); err != nil {
+		if _, err := tx.Exec(ctx, `UPDATE icalproxy_feeds_v2 SET webhook_pending=false WHERE id = ANY($1)`, ids); err != nil {
 			return internal.ErrWrap(err, "updating row")
 		}
 		count += len(urls)

--- a/notifier/notifier_test.go
+++ b/notifier/notifier_test.go
@@ -108,7 +108,7 @@ var _ = Describe("notifier", func() {
 			Expect(notifier.New(ag).Run(ctx)).To(Succeed())
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://notifiertest.localhost/feed-5'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://notifiertest.localhost/feed-5'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(HaveField("WebhookPending", false))
@@ -134,7 +134,7 @@ var _ = Describe("notifier", func() {
 			Expect(notifier.New(ag).Run(ctx)).To(MatchError(ContainSubstring("error sending webhook: 503")))
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = 'https://notifiertest.localhost/feed'`)),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = 'https://notifiertest.localhost/feed'`)),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(HaveField("WebhookPending", true))

--- a/refresher/refresher.go
+++ b/refresher/refresher.go
@@ -47,7 +47,7 @@ func (r *Refresher) Run(ctx context.Context) error {
 func (r *Refresher) buildSelectQuery(now time.Time) string {
 	whereSql := r.buildSelectQueryWhere(now)
 	q := fmt.Sprintf(`SELECT url, contents_md5, fetch_status, fetch_headers
-FROM icalproxy_feeds_v1
+FROM icalproxy_feeds_v2
 WHERE %s
 LIMIT %d
 FOR UPDATE SKIP LOCKED
@@ -91,7 +91,7 @@ func (r *Refresher) SelectRowsToProcess(ctx context.Context, tx pgx.Tx) ([]RowTo
 func (r *Refresher) ExplainSelectQuery(ctx context.Context) (string, error) {
 	var lines []string
 	err := pgxt.WithTransaction(ctx, r.ag.DB, func(tx pgx.Tx) error {
-		if _, err := tx.Exec(ctx, "SET enable_seqscan = OFF; ANALYZE icalproxy_feeds_v1"); err != nil {
+		if _, err := tx.Exec(ctx, "SET enable_seqscan = OFF; ANALYZE icalproxy_feeds_v2"); err != nil {
 			return err
 		}
 		lns, err := pgxt.GetScalars[string](ctx, r.ag.DB, "EXPLAIN ANALYZE "+r.buildSelectQuery(time.Now()))
@@ -106,7 +106,7 @@ func (r *Refresher) ExplainSelectQuery(ctx context.Context) (string, error) {
 
 func (r *Refresher) CountRowsAwaitingRefresh(ctx context.Context) (int64, error) {
 	whereSql := r.buildSelectQueryWhere(time.Now())
-	q := fmt.Sprintf(`SELECT count(1) FROM icalproxy_feeds_v1 WHERE %s`, whereSql)
+	q := fmt.Sprintf(`SELECT count(1) FROM icalproxy_feeds_v2 WHERE %s`, whereSql)
 	return pgxt.GetScalar[int64](ctx, r.ag.DB, q)
 }
 

--- a/refresher/refresher_test.go
+++ b/refresher/refresher_test.go
@@ -95,7 +95,7 @@ var _ = Describe("refresher", func() {
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -145,7 +145,7 @@ var _ = Describe("refresher", func() {
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 
 			rows := fp.Must(pgx.CollectRows[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE starts_with(url, $1)`, origin.URL())),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE starts_with(url, $1)`, origin.URL())),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(rows).To(And(
@@ -190,7 +190,7 @@ var _ = Describe("refresher", func() {
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -215,7 +215,7 @@ var _ = Describe("refresher", func() {
 			)
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 			// Set this to need to be checked again
-			_, err := ag.DB.Exec(ctx, "UPDATE icalproxy_feeds_v1 SET checked_at=$1 WHERE url=$2", time.Now().Add(-5*time.Hour), origin.URL()+"/feed.ics")
+			_, err := ag.DB.Exec(ctx, "UPDATE icalproxy_feeds_v2 SET checked_at=$1 WHERE url=$2", time.Now().Add(-5*time.Hour), origin.URL()+"/feed.ics")
 			Expect(err).ToNot(HaveOccurred())
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 			messages := fp.Map(hook.Records(), func(r logctx.HookRecord) string { return r.Record.Message })
@@ -238,7 +238,7 @@ var _ = Describe("refresher", func() {
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -265,7 +265,7 @@ var _ = Describe("refresher", func() {
 
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -294,7 +294,7 @@ var _ = Describe("refresher", func() {
 
 			Expect(refresher.New(ag).Run(ctx)).To(Succeed())
 			row := fp.Must(pgx.CollectExactlyOneRow[FeedRow](
-				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v1 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
+				fp.Must(ag.DB.Query(ctx, `SELECT * FROM icalproxy_feeds_v2 WHERE url = $1`, origin.URL()+"/expired-ttl.ics")),
 				pgx.RowToStructByName[FeedRow],
 			))
 			Expect(row).To(And(
@@ -348,13 +348,13 @@ var _ = Describe("refresher", func() {
 			Expect(err).NotTo(HaveOccurred())
 			// Limit  (cost=12.54..16.57 rows=1 width=63) (actual time=0.025..0.025 rows=0 loops=1)
 			//  ->  LockRows  (cost=12.54..16.57 rows=1 width=63) (actual time=0.024..0.024 rows=0 loops=1)
-			//        ->  Bitmap Heap Scan on icalproxy_feeds_v1  (cost=12.54..16.56 rows=1 width=63) (actual time=0.023..0.024 rows=0 loops=1)
+			//        ->  Bitmap Heap Scan on icalproxy_feeds_v2  (cost=12.54..16.56 rows=1 width=63) (actual time=0.023..0.024 rows=0 loops=1)
 			//              Recheck Cond: (starts_with(url_host_rev, 'GROELPMAXE'::text) OR (checked_at < ('2025-01-19 00:26:55+00'::timestamp with time zone - '02:00:00'::interval)))
 			//              Filter: ((starts_with(url_host_rev, 'GROELPMAXE'::text) AND (checked_at < ('2025-01-19 00:26:55+00'::timestamp with time zone - '00:01:00'::interval))) OR (checked_at < ('2025-01-19 00:26:55+00'::timestamp with time zone - '02:00:00'::interval)))
 			//              ->  BitmapOr  (cost=12.54..12.54 rows=1 width=0) (actual time=0.021..0.021 rows=0 loops=1)
-			//                    ->  Bitmap Index Scan on icalproxy_feeds_v1_url_host_rev_idx  (cost=0.00..8.27 rows=1 width=0) (actual time=0.018..0.018 rows=0 loops=1)
+			//                    ->  Bitmap Index Scan on icalproxy_feeds_v2_url_host_rev_idx  (cost=0.00..8.27 rows=1 width=0) (actual time=0.018..0.018 rows=0 loops=1)
 			//                          Index Cond: ((url_host_rev >= 'GROELPMAXE'::text) AND (url_host_rev < 'GROELPMAXF'::text))
-			//                    ->  Bitmap Index Scan on icalproxy_feeds_v1_checked_at_idx  (cost=0.00..4.27 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=1)
+			//                    ->  Bitmap Index Scan on icalproxy_feeds_v2_checked_at_idx  (cost=0.00..4.27 rows=1 width=0) (actual time=0.002..0.002 rows=0 loops=1)
 			//                          Index Cond: (checked_at < ('2025-01-19 00:26:55+00'::timestamp with time zone - '02:00:00'::interval))
 			// Planning Time: 0.868 ms
 			// Execution Time: 0.551 ms

--- a/server/server.go
+++ b/server/server.go
@@ -11,6 +11,8 @@ import (
 	"github.com/webhookdb/icalproxy/appglobals"
 	"github.com/webhookdb/icalproxy/db"
 	"github.com/webhookdb/icalproxy/feed"
+	"github.com/webhookdb/icalproxy/feedstorage"
+	"github.com/webhookdb/icalproxy/internal"
 	"github.com/webhookdb/icalproxy/pgxt"
 	"github.com/webhookdb/icalproxy/refresher"
 	"github.com/webhookdb/icalproxy/types"
@@ -142,12 +144,10 @@ func (h *endpointHandler) serveIfTtl(ctx context.Context) (bool, error) {
 	maxTtl := time.Duration(feed.TTLFor(h.url, h.ag.Config.IcalTTLMap))
 	if timeSinceFetch <= maxTtl {
 		fd, err := db.New(h.ag.DB).FetchContentsAsFeed(ctx, h.ag.FeedStorage, h.url)
-		if err != nil {
-			return false, ErrFallback
-		}
-		if fd.Body == nil {
-			// Assume the contents weren't in the database/storage, so need to be refetched and stored.
+		if errors.Is(err, feedstorage.ErrNotFound) {
 			return false, nil
+		} else if err != nil {
+			return false, ErrFallback
 		}
 		h.c.Response().Header().Set("Ical-Proxy-Cached", "true")
 		return true, h.serveResponse(ctx, fd)
@@ -171,12 +171,19 @@ func (h *endpointHandler) refetchAndCommit(ctx context.Context) (*feed.Feed, err
 	} else if errors.Is(err, feed.ErrNotModified) {
 		// If origin told us there are no changes, we need to commit the feed to reset its TTL,
 		// and then serve whatever is in cache.
-		if err := db.New(h.ag.DB).CommitUnchanged(ctx, fd); err != nil {
+		dbo := db.New(h.ag.DB)
+		if err := dbo.CommitUnchanged(ctx, fd); err != nil {
 			logctx.Logger(ctx).With("error", err).ErrorContext(ctx, "commit_unchanged_feed_error")
 		}
-		fd, err := db.New(h.ag.DB).FetchContentsAsFeed(ctx, h.ag.FeedStorage, h.url)
+		fd, err := dbo.FetchContentsAsFeed(ctx, h.ag.FeedStorage, h.url)
 		if err != nil {
 			return nil, ErrFallback
+		} else if fd.Body == nil {
+			logctx.Logger(ctx).ErrorContext(ctx, "unchanged_feed_body_empty")
+			if err := dbo.ExpireFeed(ctx, h.url); err != nil {
+				return nil, internal.ErrWrap(err, "expiring feed")
+			}
+			return h.refetchAndCommit(ctx)
 		}
 		return fd, nil
 	}

--- a/server/server.go
+++ b/server/server.go
@@ -246,7 +246,7 @@ func handleStats(ag *appglobals.AppGlobals) echo.HandlerFunc {
 			refreshRowCnt = -1
 		}
 		countLatency := time.Since(countStart)
-		whRowCnt, err := pgxt.GetScalar[int64](ctx, ag.DB, "SELECT count(1) FROM icalproxy_feeds_v1 WHERE webhook_pending")
+		whRowCnt, err := pgxt.GetScalar[int64](ctx, ag.DB, "SELECT count(1) FROM icalproxy_feeds_v2 WHERE webhook_pending")
 		if err != nil {
 			logctx.Logger(ctx).With("error", err).ErrorContext(ctx, "counting_rows_pending_webhook")
 			whRowCnt = -1

--- a/server/server.go
+++ b/server/server.go
@@ -145,6 +145,10 @@ func (h *endpointHandler) serveIfTtl(ctx context.Context) (bool, error) {
 		if err != nil {
 			return false, ErrFallback
 		}
+		if fd.Body == nil {
+			// Assume the contents weren't in the database/storage, so need to be refetched and stored.
+			return false, nil
+		}
 		h.c.Response().Header().Set("Ical-Proxy-Cached", "true")
 		return true, h.serveResponse(ctx, fd)
 	}

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/webhookdb/icalproxy/config"
 	"github.com/webhookdb/icalproxy/db"
 	"github.com/webhookdb/icalproxy/feed"
+	"github.com/webhookdb/icalproxy/feedstorage/fakefeedstorage"
 	"github.com/webhookdb/icalproxy/fp"
 	"github.com/webhookdb/icalproxy/icalproxytest"
 	"github.com/webhookdb/icalproxy/server"
@@ -150,6 +151,31 @@ var _ = Describe("server", func() {
 				HaveKeyWithValue("Content-Type", "application/custom"),
 				HaveKeyWithValue("Ical-Proxy-Origin-Error", "403"),
 			))
+		})
+		Describe("with a feed in the database but not in storage", func() {
+			It("fetches from origin and serves there was no stored body", func() {
+				fs := fakefeedstorage.New()
+				ag.FeedStorage = fs
+				Expect(db.New(ag.DB).CommitFeed(ctx, ag.FeedStorage, feed.New(
+					originFeedUri,
+					make(map[string]string),
+					200,
+					[]byte("VEVENT"),
+					time.Now(),
+				), nil)).To(Succeed())
+				fs.Files = make(map[int64][]byte)
+				origin.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/feed.ics", ""),
+						ghttp.RespondWith(200, "FETCHED"),
+					),
+				)
+				req := NewRequest("GET", serverRequestUrl, nil)
+				rr := Serve(e, req)
+				Expect(rr).To(HaveResponseCode(200))
+				Expect(rr.Body.String()).To(Equal("FETCHED"))
+			})
+
 		})
 		Describe("with a cached feed", func() {
 			BeforeEach(func() {

--- a/server/server_test.go
+++ b/server/server_test.go
@@ -287,6 +287,33 @@ var _ = Describe("server", func() {
 				Expect(rr).To(HaveResponseCode(200))
 				Expect(rr.Body.String()).To(Equal("VERSION1"))
 			})
+			It("re-fetches from Origin if origin returned NotModified on fetch, but we had no body", func() {
+				// Remove the stored feed by replacing the storage entirely
+				ag.FeedStorage = fakefeedstorage.New()
+				Expect(db.New(ag.DB).CommitFeed(ctx, ag.FeedStorage, feed.New(
+					originFeedUri,
+					make(map[string]string),
+					200,
+					nil,
+					time.Now().Add(-5*time.Hour),
+				), nil)).To(Succeed())
+				origin.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/feed.ics", ""),
+						ghttp.RespondWith(304, ""),
+					),
+				)
+				origin.AppendHandlers(
+					ghttp.CombineHandlers(
+						ghttp.VerifyRequest("GET", "/feed.ics", ""),
+						ghttp.RespondWith(200, "REFETCHED"),
+					),
+				)
+				req := NewRequest("GET", serverRequestUrl, nil)
+				rr := Serve(e, req)
+				Expect(rr).To(HaveResponseCode(200))
+				Expect(rr.Body.String()).To(Equal("REFETCHED"))
+			})
 		})
 		Describe("when the database is down", func() {
 			It("calls and returns from the origin", func() {
@@ -381,8 +408,8 @@ var _ = Describe("server", func() {
 			Expect(rr).To(HaveResponseCode(200))
 			Expect(MustUnmarshalFrom(rr.Body)).To(And(
 				HaveKey("db_count_latency"),
-				HaveKeyWithValue("pending_refresh_count", BeEquivalentTo(0)),
-				HaveKeyWithValue("pending_webhooks", BeEquivalentTo(0)),
+				HaveKey("pending_refresh_count"),
+				HaveKey("pending_webhooks"),
 			))
 		})
 	})


### PR DESCRIPTION
Update database table to v2

We are going to need to refetch all feeds as part of
the new storage rollout; we may as well create a new table,
which will give more predictable behavior and be easier to monitor.

Operators will need to drop their v1 tables once they're done.

---

Better handle unstored bodies

We should treat a missing feed as an error now.
If it happens, we should always throw away what is in the database
and pull new data down.
